### PR TITLE
Add adserver dotenv

### DIFF
--- a/api/Session.js
+++ b/api/Session.js
@@ -27,9 +27,10 @@ class Session {
     const vastObj = VastBuilder({
       sessionId: this.sessionId,
       desiredDuration: queryParams.dur || "0",
-      adserverHostname: `${process.env.HOST || "127.0.0.1"}:${
-        process.env.PORT || "8080"
-      }`,
+      adserverHostname:
+        process.env.ADSERVER ||
+        `${process.env.HOST}:${process.env.PORT}` ||
+        "localhost:8080",
     });
 
     this.#vastXml = queryParams.response || vastObj.xml;


### PR DESCRIPTION
In the vast builder, if there is a env called ADSERVER, use that, otherwise HOST env and PORT env, otherwise -> localhost (for deving)