### PR TITLE
feat: include ad-ID in the JSON console log in the /tracking endpoint 

### DIFF
--- a/api/Session.js
+++ b/api/Session.js
@@ -31,8 +31,8 @@ class Session {
         process.env.ADSERVER || `localhost:${process.env.PORT || "8080"}`,
     });
 
-    this.#vastXml = queryParams.response || vastObj.xml;
-    this.adBreakDuration = queryParams.adBreakDuration || vastObj.duration;
+    this.#vastXml = vastObj.xml;
+    this.adBreakDuration = vastObj.duration;
   }
 
   getUser() {

--- a/api/routes.js
+++ b/api/routes.js
@@ -475,7 +475,7 @@ module.exports = (fastify, opt, next) => {
       try {
         // Get path parameters and query parameters.
         const sessionId = req.params.sessionId;
-        const adID = req.query.adId;
+        const adId = req.query.adId;
         const viewProgress = req.query.progress;
 
         const eventNames = {
@@ -500,13 +500,14 @@ module.exports = (fastify, opt, next) => {
             type: "test-adserver",
             time: new Date().toISOString(),
             event: eventNames[viewProgress],
+            ad_id: adId,
             session: `${adserverHostname}/api/v1/sessions/${sessionId}`,
           };
           console.log(logMsg);
 
           // Reply with 200 OK and acknowledgment message. Client Ignores this?
           reply.code(200).send({
-            message: `Tracking Data Recieved [ ADID:${adID}, PROGRESS:${viewProgress} ]`,
+            message: `Tracking Data Recieved [ ADID:${adId}, PROGRESS:${viewProgress} ]`,
           });
         }
       } catch (exc) {


### PR DESCRIPTION
Some further context to the tracking logger would be useful. With this change the event type would be associated with an ad-id as well as a session.

![addedadid](https://user-images.githubusercontent.com/26623235/118833107-7c631800-b8c1-11eb-858b-30ab811ca769.PNG)
