### PR TITLE
Query parameter 'userAgent' overrides value used in header on VAST request.

### DIFF
--- a/api/Session.js
+++ b/api/Session.js
@@ -38,8 +38,8 @@ class Session {
       podSize: params.ps || null
     });
 
-    this.#vastXml = vastObj.xml;
-    this.adBreakDuration = vastObj.duration;
+    this.#vastXml = queryParams.response || vastObj.xml;
+    this.adBreakDuration = queryParams.adBreakDuration || vastObj.duration;
   }
 
   getUser() {

--- a/api/Session.js
+++ b/api/Session.js
@@ -38,8 +38,8 @@ class Session {
       podSize: params.ps || null
     });
 
-    this.#vastXml = queryParams.response || vastObj.xml;
-    this.adBreakDuration = queryParams.adBreakDuration || vastObj.duration;
+    this.#vastXml = vastObj.xml;
+    this.adBreakDuration = vastObj.duration;
   }
 
   getUser() {

--- a/api/routes.js
+++ b/api/routes.js
@@ -482,6 +482,11 @@ const schemas = {
           description: "Desired Pod size in numbers of Ads.",
           example: "3",
         },
+        userAgent: {
+          type: "string",
+          description: "Client's user agent",
+          example: "Mozilla/5.0",
+        },
       },
     },
     response: {
@@ -705,15 +710,18 @@ module.exports = (fastify, opt, next) => {
             return "Not found";
           }
         });
-          req.query['uip'] = parseIp(req);
+        req.query['uip'] = parseIp(req);
       }
 
-      // Parse user agent, browser language, and host from request header
-      const userAgent = req.headers['user-agent'] || "Not Found";
+      // If client didn't send user-agent as query, then read from header
+      if (!req.query['userAgent']) {
+        req.query['userAgent'] = req.headers['user-agent'] || "Not Found";
+      }
+      // Parse browser language, and host from request header
       const acceptLanguage = req.headers['accept-language'] || "Not Found";
       const host = req.headers['host'];
 
-      const params = Object.assign(req.query, {userAgent: userAgent, acceptLang: acceptLanguage, host: host});
+      const params = Object.assign(req.query, { acceptLang: acceptLanguage, host: host });
       // Create new session, then add to session DB.
       const session = new Session(params);
       const result = await DBAdapter.AddSessionToStorage(session);


### PR DESCRIPTION
To address #36.
User IP was already overridable. However, userAgent was not. This was fixed in this PR. 