### PR TITLE
Dynamic mrss collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Let's say we set `MRSS_ORIGIN=https://mrss.adtest.eyevinn.technology/` and are h
 Knowing the adserver host and `MRSS_ORIGIN`, the test-adserver will then fetch the feed.mrss file from:
 `https://mrss.adtest.eyevinn.technology/your.chosen.host.mrss`. So make sure that an mRSS feed is available on such an URL. If the url becomes unreachable, then the test-adserver will go back to the default ads.
 
+Alternatively, you can specify what file contains the collection of ads through the `coll` parameter on the `/api/v1/vast` or `/api/v1/vmap` request. In this case, the file will be expected to be at `${MRSS_ORIGIN}${coll}.mrss`. This is useful for example if you want to switch easily between different collection of ads without having to host multiple ad servers.
+
 ### MRSS Feed Structure
 The test-adserver is expecting an mRSS feed which should include text/xml with the following structure:
 ```

--- a/api/Session.js
+++ b/api/Session.js
@@ -47,6 +47,7 @@ class Session {
           maxPodDuration: params.max || null,
           minPodDuration: params.min || null,
           podSize: params.ps || null,
+          adCollection: params.coll || null,
         },
       });
       this.#vmapXml = vmapObj.xml;
@@ -60,6 +61,7 @@ class Session {
         maxPodDuration: params.max || null,
         minPodDuration: params.min || null,
         podSize: params.ps || null,
+        adCollection: params.coll || null,
       });
       this.#vastXml = vastObj.xml;
       this.adBreakDuration = vastObj.duration;

--- a/api/routes.js
+++ b/api/routes.js
@@ -607,6 +607,11 @@ const schemas = {
           description: "Client's user agent",
           example: "Mozilla/5.0",
         },
+        scope: {
+          type: "string",
+          description: "A way to target the call to a specific set of ads. The ads can be stored in an MRSS file on MRSS_ORIGIN named '{scope}.mrss'",
+          example: "my-mrss-file",
+        }
       },
     },
     response: {
@@ -1022,7 +1027,10 @@ module.exports = (fastify, opt, next) => {
 
       // Use Ads from mRSS if origin is specified
       if (process.env.MRSS_ORIGIN) {
-        const feedUri = `${process.env.MRSS_ORIGIN}${host}.mrss`;
+        const mrssFileBaseName = req.query['scope'] || host
+        
+        const feedUri = `${process.env.MRSS_ORIGIN}${mrssFileBaseName}.mrss`;
+
         if (!TENANT_CACHE[host]) {
           await UpdateCache(host, feedUri, TENANT_CACHE);
         } else {

--- a/api/routes.js
+++ b/api/routes.js
@@ -702,6 +702,11 @@ const schemas = {
           description: "Client's user agent",
           example: "Mozilla/5.0",
         },
+        coll: {
+          type: "string",
+          description: "A way to target the call to a specific collection of ads. The ads can be stored in an MRSS file on MRSS_ORIGIN named '{coll}.mrss'",
+          example: "my-cat-ads",
+        }
       },
     },
     response: {

--- a/api/routes.js
+++ b/api/routes.js
@@ -607,10 +607,10 @@ const schemas = {
           description: "Client's user agent",
           example: "Mozilla/5.0",
         },
-        scope: {
+        coll: {
           type: "string",
-          description: "A way to target the call to a specific set of ads. The ads can be stored in an MRSS file on MRSS_ORIGIN named '{scope}.mrss'",
-          example: "my-mrss-file",
+          description: "A way to target the call to a specific collection of ads. The ads can be stored in an MRSS file on MRSS_ORIGIN named '{coll}.mrss'",
+          example: "my-cat-ads",
         }
       },
     },
@@ -1027,16 +1027,16 @@ module.exports = (fastify, opt, next) => {
 
       // Use Ads from mRSS if origin is specified
       if (process.env.MRSS_ORIGIN) {
-        const mrssFileBaseName = req.query['scope'] || host
+        const collection = req.query['coll'] || host
         
-        const feedUri = `${process.env.MRSS_ORIGIN}${mrssFileBaseName}.mrss`;
+        const feedUri = `${process.env.MRSS_ORIGIN}${collection}.mrss`;
 
-        if (!TENANT_CACHE[host]) {
-          await UpdateCache(host, feedUri, TENANT_CACHE);
+        if (!TENANT_CACHE[collection]) {
+          await UpdateCache(collection, feedUri, TENANT_CACHE);
         } else {
-          const age = Date.now() - TENANT_CACHE[host].lastUpdated;
+          const age = Date.now() - TENANT_CACHE[collection].lastUpdated;
           if (age >= CACHE_MAX_AGE) {
-            await UpdateCache(host, feedUri, TENANT_CACHE);
+            await UpdateCache(collection, feedUri, TENANT_CACHE);
           }
         }
       }

--- a/utils/vast-maker.js
+++ b/utils/vast-maker.js
@@ -84,6 +84,9 @@ function VastBuilder(params) {
   if (params.adserverHostname) {
     tenantId = params.adserverHostname;
   }
+  if (params.adCollection) {
+    tenantId = params.adCollection;
+  }
   if (!TENANT_CACHE[tenantId]) {
     adList = DEFAULT_AD_LIST;
   } else {

--- a/utils/vmap-maker.js
+++ b/utils/vmap-maker.js
@@ -84,6 +84,7 @@ function VmapBuilder(params) {
     maxPodDuration: null,
     minPodDuration: null,
     podSize: null,
+    adCollection: GVC.adCollection,
   };
 
   const breakpoints = params.breakpoints ? params.breakpoints.split(",").filter((item) => !isNaN(Number(item))) : [];


### PR DESCRIPTION
As alternative to the MRSS ad collection being defined by the ad server host, and for more dynamic situations, the name of the collection (basename of the MRSS file on $MRSS_ORIGIN) can be stipulated as a `coll` parameter on the /vast or /vmap requests