### PR TITLE
skipoffset added to AttachPodAds 

### DIFF
--- a/api/ClientRequest.js
+++ b/api/ClientRequest.js
@@ -2,6 +2,7 @@ class ClientRequest {
   // Private fields
   #consent;
   #requestedDuration;
+  #skipoffset;
   #userId;
   #operatingSystem;
   #deviceType;
@@ -18,6 +19,7 @@ class ClientRequest {
   constructor(params) {
     this.#consent = params.c || null;
     this.#requestedDuration = params.dur || null;
+    this.#skipoffset = params.skip || null;
     this.#userId = params.uid || null;
     this.#operatingSystem = params.os || null;
     this.#deviceType = params.dt || null;
@@ -41,6 +43,7 @@ class ClientRequest {
     const properties = {
       Consent: this.#consent,
       RequestedDuration: this.#requestedDuration,
+      Skipoffset: this.#skipoffset,
       UserId: this.#userId,
       OperatingSystem: this.#operatingSystem,
       DeviceType: this.#deviceType,

--- a/api/Session.js
+++ b/api/Session.js
@@ -58,6 +58,7 @@ class Session {
       const vastObj = VastBuilder({
         sessionId: this.sessionId,
         desiredDuration: params.dur || "0",
+        skipoffset: params.skip || null,
         adserverHostname: this.host,
         maxPodDuration: params.max || null,
         minPodDuration: params.min || null,

--- a/api/Session.js
+++ b/api/Session.js
@@ -43,6 +43,7 @@ class Session {
         generalVastConfigs: {
           sessionId: this.sessionId,
           desiredDuration: params.dur || "0",
+          skipoffset: params.skip || null,
           adserverHostname: this.host,
           maxPodDuration: params.max || null,
           minPodDuration: params.min || null,

--- a/api/routes.js
+++ b/api/routes.js
@@ -583,7 +583,7 @@ const schemas = {
         skip: {
           type: "string",
           description: "Skipoffset in seconds or percentage.",
-          example: "00:00:05 or 25%",
+          example: "5 or 25%",
         },
         uid: {
           type: "string",
@@ -682,6 +682,11 @@ const schemas = {
           type: "string",
           description: "Desired duration for midroll ad break, in seconds.",
           example: "60",
+        },
+        skip: {
+          type: "string",
+          description: "Skipoffset in seconds or percentage.",
+          example: "5 or 25%",
         },
         uid: {
           type: "string",

--- a/api/routes.js
+++ b/api/routes.js
@@ -140,6 +140,11 @@ const vastSchema = () => ({
                   Linear: {
                     type: "object",
                     properties: {
+                      skipoffset: {
+                        type: "string",
+                        example: "00:00:05",
+                        xml: { attribute: true },
+                      },
                       Duration: {
                         type: "string",
                         example: "00:00:30",
@@ -574,6 +579,11 @@ const schemas = {
           type: "string",
           description: "Desired duration in seconds.",
           example: "60",
+        },
+        skip: {
+          type: "string",
+          description: "Skipoffset in seconds or percentage.",
+          example: "00:00:05 or 25%",
         },
         uid: {
           type: "string",

--- a/utils/vast-maker.js
+++ b/utils/vast-maker.js
@@ -209,7 +209,7 @@ function AttachPodAds(vast, podAds, params) {
       );
     }
     mediaNode = mediaNode
-      .attachLinear()
+      .attachLinear({ skipoffset: "00:00:05" }) // skipoffset does not seem to exist on VAST 2.0 and lower, you could also have skipoffset in percentage
       .attachTrackingEvents()
       .addTracking(`http://${params.adserverHostname}/api/v1/sessions/${params.sessionId}/tracking?${adId}=${podAds[i].id}_${i + 1}&progress=0`, { event: "start" })
       .addTracking(`http://${params.adserverHostname}/api/v1/sessions/${params.sessionId}/tracking?${adId}=${podAds[i].id}_${i + 1}&progress=25`, { event: "firstQuartile" })

--- a/utils/vast-maker.js
+++ b/utils/vast-maker.js
@@ -208,8 +208,9 @@ function AttachPodAds(vast, podAds, params) {
         }
       );
     }
+    console.log("VAST params: ", params);
     mediaNode = mediaNode
-      .attachLinear({ skipoffset: "00:00:05" }) // skipoffset does not seem to exist on VAST 2.0 and lower, you could also have skipoffset in percentage
+      .attachLinear({skipoffset: isValidSkipOffset(params.skipoffset)}) // skipoffset does not seem to exist on VAST 2.0 and lower, you could also have skipoffset in percentage
       .attachTrackingEvents()
       .addTracking(`http://${params.adserverHostname}/api/v1/sessions/${params.sessionId}/tracking?${adId}=${podAds[i].id}_${i + 1}&progress=0`, { event: "start" })
       .addTracking(`http://${params.adserverHostname}/api/v1/sessions/${params.sessionId}/tracking?${adId}=${podAds[i].id}_${i + 1}&progress=25`, { event: "firstQuartile" })
@@ -349,6 +350,15 @@ function indexOfSmallest(a) {
     if (a[i] < a[lowest]) lowest = i;
   }
   return lowest;
+}
+
+// Validate params.skipoffset is a valid VAST skipoffset value ("x%" or "hh:mm:ss").
+function isValidSkipOffset(skipoffset) {
+  // "hh:mm:ss"
+  const timeFormatRegex = /^(\d{2}):([0-5][0-9]):([0-5][0-9])$/;
+  // "x%"
+  const percentageFormatRegex = /^(100|[1-9]?[0-9])%$/;
+  return timeFormatRegex.test(skipoffset) || percentageFormatRegex.test(skipoffset) ? skipoffset: null;
 }
 
 function PopulatePod(_size, _min, _max, _ads, _chosenAds, _method, _targetDur) {

--- a/utils/vast-maker.js
+++ b/utils/vast-maker.js
@@ -86,7 +86,6 @@ const DEFAULT_AD_LIST = [
  * 
  */
 function VastBuilder(params) {
-  console.log("VastBuilder params: ", params);
   let vastObject = {};
   let adList = [];
   let vast = null;
@@ -352,16 +351,13 @@ function indexOfSmallest(a) {
   return lowest;
 }
 
-// Validate that params.skipoffset is a valid VAST skipoffset value ("x%" or "hh:mm:ss").
 function getSkipOffsetValue(skipoffset) {
-  // "hh:mm:ss"
-  const timeFormatRegex = /^(\d{2}):([0-5][0-9]):([0-5][0-9])$/;
   // "x%"
   const percentageFormatRegex = /^(100|[1-9]?[0-9])%$/;
   // "seconds"
   const integerSecondsRegex = /^\d+$/;
 
-  if (timeFormatRegex.test(skipoffset) || percentageFormatRegex.test(skipoffset)){
+  if (percentageFormatRegex.test(skipoffset)){
     return skipoffset;
   } 
   // convert seconds to "hh:mm:ss" format

--- a/utils/vmap-maker.js
+++ b/utils/vmap-maker.js
@@ -91,7 +91,6 @@ function VmapBuilder(params) {
 
   const breakpoints = params.breakpoints ? params.breakpoints.split(",").filter((item) => !isNaN(Number(item))) : [];
   if (params.preroll) {
-    //console.log("PARAMS: ",params.generalVastConfigs);
     const preVast = VastBuilder(defaultConfigs);
     vmap.attachAdBreak("preroll.ad", "linear", "start", preVast.xml, {
       sessionId: GVC.sessionId,

--- a/utils/vmap-maker.js
+++ b/utils/vmap-maker.js
@@ -80,6 +80,7 @@ function VmapBuilder(params) {
   const defaultConfigs = {
     sessionId: GVC.sessionId,
     desiredDuration: "15",
+    skipoffset: GVC.skipoffset,
     adserverHostname: GVC.adserverHostname,
     maxPodDuration: null,
     minPodDuration: null,
@@ -90,6 +91,7 @@ function VmapBuilder(params) {
 
   const breakpoints = params.breakpoints ? params.breakpoints.split(",").filter((item) => !isNaN(Number(item))) : [];
   if (params.preroll) {
+    //console.log("PARAMS: ",params.generalVastConfigs);
     const preVast = VastBuilder(defaultConfigs);
     vmap.attachAdBreak("preroll.ad", "linear", "start", preVast.xml, {
       sessionId: GVC.sessionId,


### PR DESCRIPTION
We added an attribute to the attachLinear method in AttachPodAds. We set it as 5 seconds but it could be changed to another value or a percentage. Right now it's very straightforward, every ad will be skippable after 5 seconds, assuming they're longer than 5 seconds. We could also make it so that we look for a skipoffset value from the ads properties and if they have one we'll add it to the params of the builder so you can choose skipoffset value or not have one at all. 

Also a small sidenote, the skipoffset attribute for the <Linear> tag is not part of VAST 2.0. The builder will still create a VAST 2.0 XML to the official documentation, that is to say it wont add the attribute to the <Linear> tag if you choose VAST 2.0.