### PR TITLE
77 feature request support for returning pause ads

### DIFF
--- a/api/Session.js
+++ b/api/Session.js
@@ -5,6 +5,7 @@ const { VastBuilder } = require("../utils/vast-maker");
 const { VmapBuilder } = require("../utils/vmap-maker");
 const { v4: uuid } = require("uuid");
 const constants = require("../utils/constants");
+const { PauseAdVastBuilder } = require("../utils/pause-ad-vast-maker");
 
 class Session {
   // Public Fields
@@ -18,6 +19,7 @@ class Session {
   #user;
   #vastXml;
   #vmapXml;
+  #pauseAdVast;
   #eventTracker;
 
   constructor(params) {
@@ -33,7 +35,16 @@ class Session {
     this.#clientRequest = new ClientRequest(params);
     this.#eventTracker = new EventTracker();
 
-    if (this.responseFormat === constants.RESPONSE_FORMATS.VMAP) {
+    if (this.responseFormat === constants.RESPONSE_FORMATS.PAUSE_AD) {
+      const pauseAdObj = PauseAdVastBuilder({
+        sessionId: this.sessionId,
+        adserverHostname: this.host,
+        width: params.width,
+        height: params.height,
+        version: params.v || null,
+      });
+      this.#pauseAdVast = pauseAdObj.xml;
+    } else if (this.responseFormat === constants.RESPONSE_FORMATS.VMAP) {
       // Create VMAP object. 
       let vmapObj;
       vmapObj = VmapBuilder({
@@ -72,6 +83,10 @@ class Session {
 
   getUser() {
     return this.#user.getUserId();
+  }
+
+  getPauseAdVast() {
+    return this.#pauseAdVast;
   }
 
   getXmlResponse() {

--- a/api/routes.js
+++ b/api/routes.js
@@ -657,6 +657,41 @@ const schemas = {
     },
     security: [{ apiKey: [] }],
   },
+  "GET/pause-ad": {
+    description: "Send a VAST response for a Pause Ad and create a new session for the given User ID",
+    tags: ["vast"],
+    produces: ["application/xml"],
+    query: {
+      type: "object",
+      properties: {
+        uid: {
+          type: "string",
+          description: "User ID.",
+          example: "asbc-242-fsdv-123",
+        },
+        v: {
+          type: "string",
+          description: "VAST version to use. Default is 4. Supported values are 2, 3 and 4",
+          example: "4",
+        },
+        width: {
+          type: "integer",
+          description: "Width of the pause ad image. Default is 300.",
+          example: 400,
+        },
+        height: {
+          type: "integer",
+          description: "Height of the pause ad image. Default is 167.",
+          example: 225,
+        },
+      },
+    },
+    response: {
+      200: XmlResponseSchema("VAST"),
+      404: BadRequestSchema("Error creating VAST response for Pause Ad"),
+    },
+    security: [{ apiKey: [] }],
+  },
   "GET/vmap": {
     description:
       "Send a VMAP response, then create a new session for the given User ID",
@@ -1177,6 +1212,69 @@ module.exports = (fastify, opt, next) => {
           label: req.headers["host"],
         });
       }
+      reply.code(500).send({ message: exc.message });
+    }
+  });
+
+  /**
+  * GET endpoint to retrieve VAST XML for Pause Ads.
+  */
+  fastify.get("/pause-ad", { schema: schemas["GET/pause-ad"] }, async (req, reply) => {
+    try {
+      logger.info(req.query, {
+        label: req.headers["host"],
+      });
+      CloudWatchLog("PAUSE_AD_REQUESTED", req.headers["host"], {});
+  
+      const params = Object.assign(req.query, {
+        acceptLang: req.headers["accept-language"] || "Not Found",
+        host: req.headers["host"],
+        userAgent: req.headers["user-agent"] || "Not Found",
+        uip: req.headers["x-forwarded-for"] || req.socket.remoteAddress || "Not Found",
+        rf: RESPONSE_FORMATS.PAUSE_AD,
+        width: req.query.width ? parseInt(req.query.width) : undefined,
+        height: req.query.height ? parseInt(req.query.height) : undefined,
+      });
+
+      const session = new Session(params);
+      const result = await DBAdapter.AddSessionToStorage(session);
+      if (!result) {
+        logger.error("Could not store new session", {
+          label: params.host,
+          sessionId: session.sessionId,
+        });
+        reply.code(404).send({
+          message: "Could not store new session",
+        });
+        return;
+      }
+  
+      const pauseAdVast = session.getPauseAdVast();
+      if (!pauseAdVast) {
+        logger.error("Pause Ad VAST not found", {
+          label: params.host,
+          sessionId: session.sessionId,
+        });
+        reply.code(404).send({
+          message: "Pause Ad VAST not found",
+        });
+        return;
+      }
+  
+      logger.info("Returned Pause Ad VAST and created a session", {
+        label: req.headers["host"],
+        sessionId: session.sessionId,
+      });
+      CloudWatchLog("PAUSE_AD_RETURNED", req.headers["host"], {
+        session: session.sessionId,
+      });
+  
+      reply.header("Content-Type", "application/xml; charset=utf-8");
+      reply.code(200).send(pauseAdVast);
+    } catch (exc) {
+      logger.error(exc, {
+        label: req.headers["host"],
+      });
       reply.code(500).send({ message: exc.message });
     }
   });

--- a/test/routes.spec.js
+++ b/test/routes.spec.js
@@ -90,7 +90,6 @@ describe(" MY ROUTES", () => {
             done(err);
           }
           res.should.have.status(200);
-          res.body.should.be.a("object");
           res.should.have.header(
             "content-type",
             "application/xml; charset=utf-8"
@@ -109,7 +108,6 @@ describe(" MY ROUTES", () => {
             done(err);
           }
           res.should.have.status(200);
-          res.body.should.be.a("object");
           res.should.have.header(
             "content-type",
             "application/xml; charset=utf-8"
@@ -147,7 +145,6 @@ describe(" MY ROUTES", () => {
             done(err);
           }
           res.should.have.status(200);
-          res.body.should.be.a("object");
           res.should.have.header(
             "content-type",
             "application/xml; charset=utf-8"
@@ -164,7 +161,6 @@ describe(" MY ROUTES", () => {
             done(err);
           }
           res.should.have.status(200);
-          res.body.should.be.a("object");
           res.should.have.header(
             "content-type",
             "application/xml; charset=utf-8"

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -1,7 +1,8 @@
 
 const RESPONSE_FORMATS = {
     VMAP: "vmap1",
-    VAST: "vast4"
+    VAST: "vast4",
+    PAUSE_AD: "pause_ad"
   }
   
   const EMPTY_VAST_MSG = `.--------------- WARNING ---------------.

--- a/utils/pause-ad-vast-maker.js
+++ b/utils/pause-ad-vast-maker.js
@@ -1,0 +1,55 @@
+const createVast = require('vast-builder');
+
+function PauseAdVastBuilder(params) {
+  let vast = null;
+
+  switch (params.version) {
+    case "2":
+      vast = createVast.v2();
+      break;
+    case "3":
+      vast = createVast.v3();
+      break;
+    default:
+      vast = createVast.v4();
+      break;
+  }
+
+  const adId = vast.attrs.version === "4.0" ? "adId" : "adID";
+
+  // Use provided width and height, or default to 300x167
+  const width = params.width || 300;
+  const height = params.height || 167;
+
+  vast
+    .attachAd({ id: "pause-ad-1" })
+    .attachInLine()
+    .addAdSystem("Test Adserver")
+    .addAdTitle("Pause Ad")
+    .addImpression(`http://${params.adserverHostname}/api/v1/sessions/${params.sessionId}/tracking?${adId}=pause-ad&progress=vast`, { id: "pause-ad-impression-1" })
+    .attachCreatives()
+    .attachCreative({ id: "pause-ad-creative-1", [adId]: "pause-ad" })
+    .attachNonLinearAds()
+    .attachTrackingEvents()
+    .addTracking(`http://${params.adserverHostname}/api/v1/sessions/${params.sessionId}/tracking?${adId}=pause-ad&progress=0`, { event: "start" })
+    .addTracking(`http://${params.adserverHostname}/api/v1/sessions/${params.sessionId}/tracking?${adId}=pause-ad&progress=100`, { event: "complete" })
+    .addTracking(`http://${params.adserverHostname}/api/v1/sessions/${params.sessionId}/tracking?${adId}=pause-ad&event=pause`, { event: "pause" })
+    .and()
+    .attachNonLinear({
+      id: "pause-ad-1",
+      width: width,
+      height: height,
+      scalable: true,
+      maintainAspectRatio: true,
+      minSuggestedDuration: "00:00:05",
+      apiFramework: "static",
+    })
+    .addStaticResource("https://testcontent.eyevinn.technology/ads/STSWE_AD_001.jpg", "image/jpeg")
+    .addNonLinearClickThrough("https://github.com/Eyevinn/test-adserver");
+
+  const vastXml = vast.toXml();
+  console.log('Generated VAST XML:', vastXml);
+  return { xml: vastXml };
+}
+
+module.exports = { PauseAdVastBuilder };

--- a/utils/pause-ad-vast-maker.js
+++ b/utils/pause-ad-vast-maker.js
@@ -44,11 +44,10 @@ function PauseAdVastBuilder(params) {
       minSuggestedDuration: "00:00:05",
       apiFramework: "static",
     })
-    .addStaticResource("https://testcontent.eyevinn.technology/ads/STSWE_AD_001.jpg", "image/jpeg")
+    .addStaticResource("https://testcontent.eyevinn.technology/ads/STSWE_AD_001.jpg", {creativeType:"image/jpeg"})
     .addNonLinearClickThrough("https://github.com/Eyevinn/test-adserver");
 
   const vastXml = vast.toXml();
-  console.log('Generated VAST XML:', vastXml);
   return { xml: vastXml };
 }
 


### PR DESCRIPTION
# Add Support for Pause Ads

This PR implements a new feature to support Pause Ads in the test-adserver. It adds a new endpoint `/pause-ad` that returns a VAST XML response suitable for pause ads.

## Changes

- Added a new `/pause-ad` endpoint that generates and returns a VAST XML for pause ads
- Implemented `PauseAdVastBuilder` to create VAST XML specifically for pause ads
- Updated the `Session` class to handle pause ad requests
- Added a new response format `PAUSE_AD` to constants

## Testing

The VAST XML generated has been tested with the Video Suite Inspector (https://googleads.github.io/googleads-ima-html5/vsi/). 

**Observations:**
- The image is visible, ~~but only a cropped part of it is shown.~~
- The image is displayed continuously, regardless of whether the video is paused or not.

**Questions:**
1. Is it correct that the pause logic cannot be implemented in the XML and must be handled by the video player's logic?
2. Are there other ways to test if a pausing functionality could work with this XML?
3. ~~What might be causing only a cropped part of the image to be visible, and how can we address this?~~ (Fixed)

## Notes

- The pause ad is implemented as a non-linear ad with a static image resource.
- Users can specify the parameters User ID, Vast version, width and height for the pause ad image. (Thoughts?)
- The VAST response includes tracking events for start, complete, and pause, which can be used by compatible video players.