### PR TITLE
feat: remove the index from ad id for easier identification

### DIFF
--- a/utils/vast-maker.js
+++ b/utils/vast-maker.js
@@ -202,9 +202,9 @@ function AttachPodAds(vast, podAds, params) {
     if (vast.attrs.version === "4.0") {
       mediaNode = mediaNode
       .addUniversalAdId(
-        encodeURIComponent(`${podAds[i].universalId}`), {
+        encodeURIComponent(`${podAds[i].universalId}${i + 1}`), {
           idRegistry: "test-ad-id.eyevinn",
-          idValue: encodeURIComponent(`${podAds[i].universalId}`),
+          idValue: encodeURIComponent(`${podAds[i].universalId}${i + 1}`),
         }
       );
     }

--- a/utils/vast-maker.js
+++ b/utils/vast-maker.js
@@ -196,15 +196,15 @@ function AttachPodAds(vast, podAds, params) {
       .attachCreatives()
       .attachCreative({
         id: `CRETIVE-ID_00${i + 1}`,
-        [adId]: `${podAds[i].id}_${i + 1}`,
+        [adId]: `${podAds[i].id}`,
         sequence: `${i + 1}`,
       });
     if (vast.attrs.version === "4.0") {
       mediaNode = mediaNode
       .addUniversalAdId(
-        encodeURIComponent(`${podAds[i].universalId}${i + 1}`), {
+        encodeURIComponent(`${podAds[i].universalId}`), {
           idRegistry: "test-ad-id.eyevinn",
-          idValue: encodeURIComponent(`${podAds[i].universalId}${i + 1}`),
+          idValue: encodeURIComponent(`${podAds[i].universalId}`),
         }
       );
     }


### PR DESCRIPTION
This commit removed the index from the id in pod ads. 
It would then be easy to identify each creative by their `UniversalAdId` or `adId`.

One open question is whether to do the same for stand-alone ads or not.
```bash
@@ -152,9 +152,9 @@ function AttachStandAloneAds(vast, ads, params, podSize) {
     if (vast.attrs.version === "4.0") {
       mediaNode = mediaNode
       .addUniversalAdId(
-        encodeURIComponent(`${ads[i].universalId}${i + podSize}`), {
+        encodeURIComponent(`${ads[i].universalId}`), {
           idRegistry: "test-ad-id.eyevinn",
-          idValue: encodeURIComponent(`${ads[i].universalId}${i + podSize}`),
+          idValue: encodeURIComponent(`${ads[i].universalId}`),
         }
       );
     }
```