### PR TITLE
Tell xml parser 'url' nodes are in Array format

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The test-adserver is expecting an mRSS feed which should include text/xml with t
   <entry>                                                   
     <id>hotdog_ad_2021</id>                                 //ID for the ad
     <universalId>AAAA</universalId>                         //The ad's Universal ADID 
-    <link>https://server.hotdog_ad_1.mp4</link>             //URL to the ad resource
+    <url>https://server.hotdog_ad_1.mp4</url>               //URL to the ad resource
     <duration>00:00:16</duration>                           //Duration of ad in format-> HH:MM:SS
     <bitrate>17700</bitrate>                                //The ad's video bitrate
     <width>1920</width>                                     //The ad's video width
@@ -113,7 +113,7 @@ The test-adserver is expecting an mRSS feed which should include text/xml with t
 
 Simply populate your xml file with `<entry></entry>` tags for each Ad asset with the necessary data (id, universalId, link, duration, etc...).
 
-If you have ads in multiple formats (eg. DASH, HLS, MP4), you can add multiple `<link></link>` for each one.
+If you have ads in multiple formats (eg. DASH, HLS, MP4), you can add multiple `<url></url>` for each one.
 
 ## Commercial Options
 

--- a/utils/utilities.js
+++ b/utils/utilities.js
@@ -14,7 +14,16 @@ async function UpdateCache(tenant, feedURI, cache) {
   try {
     const response = await fetch(feedURI);
     const xml = await response.text();
-    const json = xmlparser.parse(xml);
+    
+    const xmlOptions = {
+      ignoreAttributes: false, 
+      attributeNamePrefix: "", 
+      removeNSPrefix: true, 
+      isArray: (name, jPath, isLeafNode, isAttribute) => name === "url", 
+    };
+    
+    const json = xmlparser.parse(xml, xmlOptions);
+    
     let feedEntry = json.feed.entry;
 
     // Turn to array if only one Ad was in the feed


### PR DESCRIPTION
Found out while working with the test-server that when creating a hand-crafted mrss server the xml definition given in the README is not working out of the box.

- When working with an MRSS origin:
- Mediafiles need to be enclosed in `<url>` tags. (not `<link>`) 
- The `<url>` tag needs to be treated as an Array.  As can be seen in 'vast-maker.js' `DEFAULT_AD_LIST`

This change here tells the xmlparser to treat the `<url>` tag as an Array. 

After this change, everything started working correctly for me.